### PR TITLE
Bump build tools and target SDK to latest versions

### DIFF
--- a/spyglass-sample/build.gradle
+++ b/spyglass-sample/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 11

--- a/spyglass/build.gradle
+++ b/spyglass/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 19
+        targetSdkVersion 21
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Bump build tools to latest version (21.1.2) for spyglass-sample.  Change target SDK to latest version (21) for spyglass.