### PR TITLE
disable spelling suggestions during mention suggestions

### DIFF
--- a/spyglass/src/androidTest/java/com/linkedin/android/spyglass/ui/RichEditorViewTest.java
+++ b/spyglass/src/androidTest/java/com/linkedin/android/spyglass/ui/RichEditorViewTest.java
@@ -14,7 +14,9 @@
 
 package com.linkedin.android.spyglass.ui;
 
+import android.text.InputType;
 import android.text.Spanned;
+import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -108,4 +110,17 @@ public class RichEditorViewTest {
         verify(suggestionsList).setSelection(0);
     }
 
+    @Test
+    public void testSuggestionsListDisablesSpellingSuggestions() throws Exception {
+        EditText input = TestUtils.getPrivateField(mRichEditor, "mMentionsEditText");
+        int originalInputType = input.getInputType();
+
+        mRichEditor.displaySuggestions(true);
+        // should be no suggestions
+        assertEquals(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS, input.getInputType());
+
+        mRichEditor.displaySuggestions(false);
+        // should be back to original type
+        assertEquals(originalInputType, input.getInputType());
+    }
 }


### PR DESCRIPTION
This prevents most keyboards from automatically changing the user’s
input, which alters the suggestions being displayed, since many names
are not found in a typical dictionary.