### PR TITLE
MentionSpan disappear when "Don't  keep activities"  turn on in Developer Settings

### DIFF
--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/data/models/City.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/data/models/City.java
@@ -15,6 +15,8 @@
 package com.linkedin.android.spyglass.sample.data.models;
 
 import android.content.res.Resources;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -72,6 +74,31 @@ public class City implements Mentionable {
     public String getPrimaryText() {
         return mName;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mName);
+    }
+
+    public City(Parcel in) {
+        mName = in.readString();
+    }
+
+    public static final Parcelable.Creator<City> CREATOR
+            = new Parcelable.Creator<City>() {
+        public City createFromParcel(Parcel in) {
+            return new City(in);
+        }
+
+        public City[] newArray(int size) {
+            return new City[size];
+        }
+    };
 
     // --------------------------------------------------
     // CityLoader Class (loads cities from JSON file)

--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/data/models/Person.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/data/models/Person.java
@@ -15,6 +15,8 @@
 package com.linkedin.android.spyglass.sample.data.models;
 
 import android.content.res.Resources;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -96,6 +98,34 @@ public class Person implements Mentionable {
         return getFullName();
     }
 
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mFirstName);
+        dest.writeString(mLastName);
+        dest.writeString(mPictureURL);
+    }
+
+    public Person(Parcel in) {
+        mFirstName = in.readString();
+        mLastName = in.readString();
+        mPictureURL = in.readString();
+    }
+
+    public static final Parcelable.Creator<Person> CREATOR
+            = new Parcelable.Creator<Person>() {
+        public Person createFromParcel(Parcel in) {
+            return new Person(in);
+        }
+
+        public Person[] newArray(int size) {
+            return new Person[size];
+        }
+    };
 
     // --------------------------------------------------
     // PersonLoader Class (loads people from JSON file)

--- a/spyglass/src/androidTest/java/com/linkedin/android/spyglass/mentions/TestMention.java
+++ b/spyglass/src/androidTest/java/com/linkedin/android/spyglass/mentions/TestMention.java
@@ -14,6 +14,9 @@
 
 package com.linkedin.android.spyglass.mentions;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 /**
  * Concrete implementation of the {@link Mentionable} interface for testing purposes.
  */
@@ -53,4 +56,29 @@ public class TestMention implements Mentionable {
     public MentionDeleteStyle getDeleteStyle() {
         return MentionDeleteStyle.PARTIAL_NAME_DELETE;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mText);
+    }
+
+    public TestMention(Parcel in) {
+        mText = in.readString();
+    }
+
+    public static final Parcelable.Creator<TestMention> CREATOR
+            = new Parcelable.Creator<TestMention>() {
+        public TestMention createFromParcel(Parcel in) {
+            return new TestMention(in);
+        }
+
+        public TestMention[] newArray(int size) {
+            return new TestMention[size];
+        }
+    };
 }

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionSpan.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionSpan.java
@@ -152,13 +152,9 @@ public class MentionSpan extends ClickableSpan implements Parcelable {
         dest.writeInt(SELECTED_TEXT_COLOR);
         dest.writeInt(SELECTED_BG_COLOR);
 
-        dest.writeInt(getMention().getDeleteStyle().ordinal());
         dest.writeInt(getDisplayMode().ordinal());
-        dest.writeString(getMention().getTextForDisplayMode(MentionDisplayMode.FULL));
-        dest.writeString(getMention().getTextForDisplayMode(MentionDisplayMode.PARTIAL));
         dest.writeInt(isSelected() ? 1 : 0);
-        dest.writeInt(getMention().getId());
-        dest.writeString(getMention().getPrimaryText());
+        dest.writeParcelable(getMention(), flags);
     }
 
     public MentionSpan(Parcel in) {
@@ -167,47 +163,9 @@ public class MentionSpan extends ClickableSpan implements Parcelable {
         SELECTED_TEXT_COLOR = in.readInt();
         SELECTED_BG_COLOR = in.readInt();
 
-        final Mentionable.MentionDeleteStyle deleteStyle = Mentionable.MentionDeleteStyle.values()[in.readInt()];
         mDisplayMode = MentionDisplayMode.values()[in.readInt()];
-        final String fullDisplayModeText = in.readString();
-        final String partialDisplayModeText = in.readString();
         setSelected((in.readInt() == 1));
-        final int id = in.readInt();
-        final String primaryText = in.readString();
-
-        mMention = new Mentionable() {
-            @Override
-            public String getTextForDisplayMode(MentionDisplayMode mentionDisplayMode) {
-                String text = "";
-                switch (mentionDisplayMode) {
-                    case FULL:
-                        text = fullDisplayModeText;
-                        break;
-                    case PARTIAL:
-                        text = partialDisplayModeText;
-                        break;
-                    default:
-                        break;
-                }
-
-                return text;
-            }
-
-            @Override
-            public MentionDeleteStyle getDeleteStyle() {
-                return deleteStyle;
-            }
-
-            @Override
-            public int getId() {
-                return id;
-            }
-
-            @Override
-            public String getPrimaryText() {
-                return primaryText;
-            }
-        };
+        mMention = in.readParcelable(Mentionable.class.getClassLoader());
     }
 
     public static final Parcelable.Creator<MentionSpan> CREATOR

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/suggestions/interfaces/Suggestible.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/suggestions/interfaces/Suggestible.java
@@ -14,6 +14,8 @@
 
 package com.linkedin.android.spyglass.suggestions.interfaces;
 
+import android.os.Parcelable;
+
 import com.linkedin.android.spyglass.suggestions.SuggestionsAdapter;
 
 /**
@@ -22,7 +24,7 @@ import com.linkedin.android.spyglass.suggestions.SuggestionsAdapter;
  * Note that the information gathered from the below methods are used in the default layout for the
  * {@link SuggestionsAdapter}.
  */
-public interface Suggestible {
+public interface Suggestible extends Parcelable {
 
     // Must be unique (useful for eliminating duplicate suggestions)
     public abstract int getId();

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -15,6 +15,8 @@
 package com.linkedin.android.spyglass.ui;
 
 import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.Editable;
@@ -849,4 +851,55 @@ public class MentionsEditText extends EditText implements TokenSource {
         mAvoidPrefixOnTap = avoidPrefixOnTap;
     }
 
+    @Override
+    public Parcelable onSaveInstanceState() {
+        Parcelable parcelable = super.onSaveInstanceState();
+        return new SavedState(parcelable, getMentionsText());
+    }
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState savedState = (SavedState) state;
+        super.onRestoreInstanceState(savedState.getSuperState());
+        setText(savedState.mentionsEditable);
+    }
+
+    /**
+     * Convenience class to save/restore the MentionsEditable state.
+     */
+    protected static class SavedState extends BaseSavedState {
+        public MentionsEditable mentionsEditable;
+
+        private SavedState(Parcelable superState, MentionsEditable mentionsEditable) {
+            super(superState);
+            this.mentionsEditable = mentionsEditable;
+        }
+
+        private SavedState(Parcel in) {
+            super(in);
+            mentionsEditable = in.readParcelable(MentionsEditable.class.getClassLoader());
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeParcelable(mentionsEditable, flags);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR = new Creator<SavedState>() {
+
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
+    }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Turn on "Don't keep activities" in developer settings.
2. Start spyglass sample app.
3. Add a mention.
4. Press home button.
5. Open the app again from the recent apps.

Actual result:
Previously added mention span will disappear and show as a normal plain text.

Expected result:
Mention span should not disappear.

Cause:
MentionSpan data were not saved when the activity was killed.

Fix:
Saved the MentionSpan data in the MentionsEditText's onSaveInstanceState and
restored in onRestoreInstanceState callbacks.