### PR TITLE
Simplified text-watching logic and new interface for mention callbacks

### DIFF
--- a/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionsEditable.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionsEditable.java
@@ -37,12 +37,25 @@ import java.util.List;
  */
 public class MentionsEditable extends SpannableStringBuilder implements Parcelable {
 
-    public MentionsEditable(CharSequence text) {
+    public MentionsEditable(@NonNull CharSequence text) {
         super(text);
     }
 
-    public MentionsEditable(CharSequence text, int start, int end) {
+    public MentionsEditable(@NonNull CharSequence text, int start, int end) {
         super(text, start, end);
+    }
+
+    public MentionsEditable(@NonNull Parcel in) {
+        super(in.readString());
+        int length = in.readInt();
+        if (length > 0) {
+            for (int index = 0; index < length; index++) {
+                int start = in.readInt();
+                int end = in.readInt();
+                MentionSpan span = new MentionSpan(in);
+                setSpan(span, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+        }
     }
 
     // --------------------------------------------------
@@ -175,19 +188,6 @@ public class MentionsEditable extends SpannableStringBuilder implements Parcelab
                 dest.writeInt(getSpanStart(span));
                 dest.writeInt(getSpanEnd(span));
                 span.writeToParcel(dest, flags);
-            }
-        }
-    }
-
-    public MentionsEditable(Parcel in) {
-        super(in.readString());
-        int length = in.readInt();
-        if (length > 0) {
-            for (int index = 0; index < length; index++) {
-                int start = in.readInt();
-                int end = in.readInt();
-                MentionSpan span = new MentionSpan(in);
-                setSpan(span, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
         }
     }

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -744,8 +744,10 @@ public class MentionsEditText extends EditText implements TokenSource {
         }
 
         @Override
-        public Editable newEditable(CharSequence source) {
-            return new MentionsEditable(source);
+        public Editable newEditable(@NonNull CharSequence source) {
+            MentionsEditable text = new MentionsEditable(source);
+            Selection.setSelection(text, 0);
+            return text;
         }
     }
 

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/wrappers/RichEditorFragment.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/wrappers/RichEditorFragment.java
@@ -36,8 +36,8 @@ public class RichEditorFragment extends Fragment {
     private RichEditorView mRichEditor;
     private OnCreateViewListener mOnCreateViewListener;
 
-    public static interface OnCreateViewListener {
-        public void onFragmentCreateView(RichEditorFragment fragment);
+    public interface OnCreateViewListener {
+        void onFragmentCreateView(RichEditorFragment fragment);
     }
 
     public RichEditorFragment() {

--- a/spyglass/src/test/java/com/linkedin/android/spyglass/ui/MentionsEditTextTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/ui/MentionsEditTextTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -74,6 +75,13 @@ public class MentionsEditTextTest {
         doReturn("a").when(mEditText).getCurrentKeywordsString();
         mEditText.onTouchEvent(event);
         verify(mEditText).setAvoidedPrefix("a");
+    }
+
+    @Test
+    public void testSelectionAtIndexZeroOnInit() {
+        MentionsEditText editText = new MentionsEditText(Robolectric.application);
+        assertEquals(0, editText.getSelectionStart());
+        assertEquals(0, editText.getSelectionEnd());
     }
 
     @Test


### PR DESCRIPTION
1. Refactored some code to simplify it
2. Small fix for an issue where the text cursor was not appearing initially as expected
3. Added interface for listening for mention additions and deletions (a bit simpler than using SpanWatcher)