### PR TITLE
Fixes to improve handling of mentions that are longer than one word

### DIFF
--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/SimpleMentions.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/SimpleMentions.java
@@ -26,6 +26,7 @@ import com.linkedin.android.spyglass.tokenization.interfaces.QueryTokenReceiver;
 import com.linkedin.android.spyglass.ui.RichEditorView;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -49,7 +50,7 @@ public class SimpleMentions extends ActionBarActivity implements QueryTokenRecei
 
     @Override
     public List<String> onQueryReceived(final @NonNull QueryToken queryToken) {
-        List<String> buckets = Arrays.asList(BUCKET);
+        List<String> buckets = Collections.singletonList(BUCKET);
         List<City> suggestions = cities.getSuggestions(queryToken);
         SuggestionsResult result = new SuggestionsResult(queryToken, suggestions);
         editor.onReceiveSuggestionsResult(result, BUCKET);

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionsEditable.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionsEditable.java
@@ -87,6 +87,24 @@ public class MentionsEditable extends SpannableStringBuilder implements Parcelab
         super.setSpan(what, start, end, flags);
     }
 
+    @NonNull
+    @Override
+    public SpannableStringBuilder replace(int start, int end, CharSequence tb, int tbstart, int tbend) {
+        // On certain software keyboards, the editor appears to append a word minus the last character when it is really
+        // trying to just delete the last character. Until we can figure out the root cause of this issue, the following
+        // code remaps this situation to do a proper delete.
+        if (start == end && start - tbend - 1 >= 0 && tb.length() > 1) {
+            String insertString = tb.subSequence(tbstart, tbend).toString();
+            String previousString = subSequence(start - tbend - 1, start - 1).toString();
+            if (insertString.equals(previousString)) {
+                // Delete a character
+                return super.replace(start - 1, start, "", 0, 0);
+            }
+        }
+
+        return super.replace(start, end, tb, tbstart, tbend);
+    }
+
     // --------------------------------------------------
     // Custom Public Methods
     // --------------------------------------------------

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/RichEditorView.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/RichEditorView.java
@@ -365,7 +365,7 @@ public class RichEditorView extends RelativeLayout implements TextWatcher, Query
             // store the previous input type
             mOriginalInputType = mMentionsEditText.getInputType();
         }
-        mMentionsEditText.setInputType(disable ? InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS : mOriginalInputType);
+        mMentionsEditText.setRawInputType(disable ? InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS : mOriginalInputType);
         mMentionsEditText.setSelection(start, end);
     }
 

--- a/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
@@ -83,4 +83,10 @@ public class MentionsEditableTest {
         assertEquals(mEditable.length(), mEditable.getSpanEnd(mMentionSpan));
     }
 
+    @Test
+    public void testMapToDeleteCharacterInsteadOfAppend() {
+        mEditable = new MentionsEditable("Hello World");
+        mEditable.replace(11, 11, "Worl");
+        assertEquals("Hello Worl", mEditable.toString());
+    }
 }


### PR DESCRIPTION
Previous commits fixed bugs when typing directly after a mention, but only handled cases where the mention was only a single word. The odd behaviors that were supposed to be fixed still existed for longer, multi-word mentions. This commit addresses these issues.