### PR TITLE
Make it much easier to customize MentionSpans

### DIFF
--- a/spyglass-sample/src/main/AndroidManifest.xml
+++ b/spyglass-sample/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
             android:label="@string/simple_mentions_sample" />
 
         <activity
+            android:name=".samples.ColorfulMentions"
+            android:label="@string/colorful_mentions_sample" />
+
+        <activity
             android:name=".samples.NetworkedMentions"
             android:label="@string/networked_mentions_sample" />
 

--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/SamplesActivity.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/SamplesActivity.java
@@ -20,6 +20,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.View;
 import android.widget.Button;
 
+import com.linkedin.android.spyglass.sample.samples.ColorfulMentions;
 import com.linkedin.android.spyglass.sample.samples.GridMentions;
 import com.linkedin.android.spyglass.sample.samples.MultiSourceMentions;
 import com.linkedin.android.spyglass.sample.samples.NetworkedMentions;
@@ -40,6 +41,14 @@ public class SamplesActivity extends ActionBarActivity {
             @Override
             public void onClick(View v) {
                 startActivity(new Intent(SamplesActivity.this, SimpleMentions.class));
+            }
+        });
+
+        Button colorfulSample = (Button) findViewById(R.id.colorful_sample);
+        colorfulSample.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(SamplesActivity.this, ColorfulMentions.class));
             }
         });
 

--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/ColorfulMentions.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/ColorfulMentions.java
@@ -1,0 +1,57 @@
+/*
+* Copyright 2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package com.linkedin.android.spyglass.sample.samples;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.ActionBarActivity;
+import com.linkedin.android.spyglass.sample.R;
+import com.linkedin.android.spyglass.sample.data.models.City;
+import com.linkedin.android.spyglass.suggestions.SuggestionsResult;
+import com.linkedin.android.spyglass.tokenization.QueryToken;
+import com.linkedin.android.spyglass.tokenization.interfaces.QueryTokenReceiver;
+import com.linkedin.android.spyglass.ui.RichEditorView;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Simple example showing customized, colorful mentions.
+ */
+public class ColorfulMentions extends ActionBarActivity implements QueryTokenReceiver {
+
+    private static final String BUCKET = "cities-memory";
+
+    private RichEditorView editor;
+    private City.CityLoader cities;
+
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.colorful_mentions);
+        editor = (RichEditorView) findViewById(R.id.editor);
+        editor.setQueryTokenReceiver(this);
+        editor.setHint(getResources().getString(R.string.type_city));
+        cities = new City.CityLoader(getResources());
+    }
+
+    @Override
+    public List<String> onQueryReceived(final @NonNull QueryToken queryToken) {
+        List<String> buckets = Collections.singletonList(BUCKET);
+        List<City> suggestions = cities.getSuggestions(queryToken);
+        SuggestionsResult result = new SuggestionsResult(queryToken, suggestions);
+        editor.onReceiveSuggestionsResult(result, BUCKET);
+        return buckets;
+    }
+}

--- a/spyglass-sample/src/main/res/layout/colorful_mentions.xml
+++ b/spyglass-sample/src/main/res/layout/colorful_mentions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical">
@@ -13,24 +14,16 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/networked_mentions_description"/>
-
-        <TextView
-            android:id="@+id/label_network_delay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-
-        <SeekBar
-            android:id="@+id/seek_network_delay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:max="50"
-            android:progress="20"/>
+            android:text="@string/colorful_mentions_description"/>
     </LinearLayout>
 
     <com.linkedin.android.spyglass.ui.RichEditorView
         android:id="@+id/editor"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:minHeight="150dp"
+        app:mentionTextBackgroundColor="@color/custom_normal_mention_text_background"
+        app:mentionTextColor="@color/custom_normal_mention_text"
+        app:selectedMentionTextBackgroundColor="@color/custom_selected_mention_text_background"
+        app:selectedMentionTextColor="@color/custom_selected_mention_text"/>
 </LinearLayout>

--- a/spyglass-sample/src/main/res/layout/grid_mention_item.xml
+++ b/spyglass-sample/src/main/res/layout/grid_mention_item.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:padding="20dp">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="20dp">
 
     <ImageView
         android:id="@+id/person_image"
@@ -16,10 +16,9 @@
         android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:layout_alignBottom="@+id/person_image"
-        android:text="{{ person.name }}"
-        android:gravity="center_horizontal"
         android:background="#7F303030"
+        android:gravity="center_horizontal"
+        android:text="{{ person.name }}"
         android:textColor="@color/primary_text_default_material_dark"
         android:textSize="16sp"/>
-
 </RelativeLayout>

--- a/spyglass-sample/src/main/res/layout/grid_mentions.xml
+++ b/spyglass-sample/src/main/res/layout/grid_mentions.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
 
     <LinearLayout
-        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#BDBDBD">
+        android:background="#BDBDBD"
+        android:orientation="vertical">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/grid_mentions_description"/>
-
     </LinearLayout>
 
     <com.linkedin.android.spyglass.ui.MentionsEditText
@@ -27,5 +26,4 @@
         android:id="@+id/mentions_grid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
-
 </LinearLayout>

--- a/spyglass-sample/src/main/res/layout/samples.xml
+++ b/spyglass-sample/src/main/res/layout/samples.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:gravity="center"
+              android:orientation="vertical">
 
     <Button
         android:id="@+id/simple_sample"
         android:layout_width="240dp"
         android:layout_height="wrap_content"
         android:text="@string/simple_mentions_sample"/>
+
+    <Button
+        android:id="@+id/colorful_sample"
+        android:layout_width="240dp"
+        android:layout_height="wrap_content"
+        android:text="@string/colorful_mentions_sample"/>
 
     <Button
         android:id="@+id/networked_sample"
@@ -29,5 +34,4 @@
         android:layout_width="240dp"
         android:layout_height="wrap_content"
         android:text="@string/grid_mentions_sample"/>
-
 </LinearLayout>

--- a/spyglass-sample/src/main/res/layout/simple_mentions.xml
+++ b/spyglass-sample/src/main/res/layout/simple_mentions.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
 
     <LinearLayout
-        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#BDBDBD">
+        android:background="#BDBDBD"
+        android:orientation="vertical">
 
         <TextView
             android:layout_width="match_parent"
@@ -22,5 +22,4 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="150dp"/>
-
 </LinearLayout>

--- a/spyglass-sample/src/main/res/values/colors.xml
+++ b/spyglass-sample/src/main/res/values/colors.xml
@@ -3,4 +3,9 @@
     <color name="action_bar">#2e8dd7</color>
     <color name="person_mention_text">#3F51B5</color>
     <color name="city_mention_text">#4CAF50</color>
+
+    <color name="custom_normal_mention_text">#ff8400</color>
+    <color name="custom_normal_mention_text_background">#bffff1</color>
+    <color name="custom_selected_mention_text">#999999</color>
+    <color name="custom_selected_mention_text_background">#ff0000</color>
 </resources>

--- a/spyglass-sample/src/main/res/values/strings.xml
+++ b/spyglass-sample/src/main/res/values/strings.xml
@@ -11,6 +11,9 @@
     <string name="simple_mentions_sample">Basic Demo</string>
     <string name="simple_mentions_description">A basic mentions widget with as little code as possible.</string>
 
+    <string name="colorful_mentions_sample">Colorful Mentions Demo</string>
+    <string name="colorful_mentions_description">Demonstrates how to set custom colors for your mentions.</string>
+
     <string name="networked_mentions_sample">Network Demo</string>
     <string name="networked_mentions_description">Shows the effect of a simulated network latency.</string>
 

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionSpanConfig.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/mentions/MentionSpanConfig.java
@@ -1,0 +1,82 @@
+/*
+* Copyright 2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package com.linkedin.android.spyglass.mentions;
+
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+
+/**
+ * Class used to configure various options for the {@link MentionSpan}. Instantiate using the
+ * {@link MentionSpanConfig.Builder} class.
+ */
+public class MentionSpanConfig {
+
+    @ColorInt public final int NORMAL_TEXT_COLOR;
+    @ColorInt public final int NORMAL_TEXT_BACKGROUND_COLOR;
+    @ColorInt public final int SELECTED_TEXT_COLOR;
+    @ColorInt public final int SELECTED_TEXT_BACKGROUND_COLOR;
+
+    MentionSpanConfig(@ColorInt final int normalTextColor,
+                      @ColorInt final int normalTextBackgroundColor,
+                      @ColorInt final int selectedTextColor,
+                      @ColorInt final int selectedTextBackgroundColor) {
+        this.NORMAL_TEXT_COLOR = normalTextColor;
+        this.NORMAL_TEXT_BACKGROUND_COLOR = normalTextBackgroundColor;
+        this.SELECTED_TEXT_COLOR = selectedTextColor;
+        this.SELECTED_TEXT_BACKGROUND_COLOR = selectedTextBackgroundColor;
+    }
+
+    public static class Builder {
+
+        // Default colors
+        @ColorInt private int normalTextColor = Color.parseColor("#00a0dc");
+        @ColorInt private int normalTextBackgroundColor = Color.TRANSPARENT;
+        @ColorInt private int selectedTextColor = Color.WHITE;
+        @ColorInt private int selectedTextBackgroundColor = Color.parseColor("#0077b5");
+
+        public Builder setMentionTextColor(@ColorInt int normalTextColor) {
+            if (normalTextColor != -1) {
+                this.normalTextColor = normalTextColor;
+            }
+            return this;
+        }
+
+        public Builder setMentionTextBackgroundColor(@ColorInt int normalTextBackgroundColor) {
+            if (normalTextBackgroundColor != -1) {
+                this.normalTextBackgroundColor = normalTextBackgroundColor;
+            }
+            return this;
+        }
+
+        public Builder setSelectedMentionTextColor(@ColorInt int selectedTextColor) {
+            if (selectedTextColor != -1) {
+                this.selectedTextColor = selectedTextColor;
+            }
+            return this;
+        }
+
+        public Builder setSelectedMentionTextBackgroundColor(@ColorInt int selectedTextBackgroundColor) {
+            if (selectedTextBackgroundColor != -1) {
+                this.selectedTextBackgroundColor = selectedTextBackgroundColor;
+            }
+            return this;
+        }
+
+        public MentionSpanConfig build() {
+            return new MentionSpanConfig(normalTextColor, normalTextBackgroundColor,
+                                         selectedTextColor, selectedTextBackgroundColor);
+        }
+    }
+}

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -15,8 +15,10 @@
 package com.linkedin.android.spyglass.ui;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.Editable;
@@ -37,7 +39,9 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
+import com.linkedin.android.spyglass.R;
 import com.linkedin.android.spyglass.mentions.MentionSpan;
+import com.linkedin.android.spyglass.mentions.MentionSpanConfig;
 import com.linkedin.android.spyglass.mentions.Mentionable;
 import com.linkedin.android.spyglass.mentions.MentionsEditable;
 import com.linkedin.android.spyglass.suggestions.interfaces.SuggestionsVisibilityManager;
@@ -53,6 +57,15 @@ import java.util.Locale;
 /**
  * Class that overrides {@link EditText} in order to have more control over touch events and selection ranges for use in
  * the {@link RichEditorView}.
+ * <p/>
+ * <b>XML attributes</b>
+ * <p/>
+ * See {@link R.styleable#MentionsEditText Attributes}
+ *
+ * @attr ref R.styleable#MentionsEditText_mentionTextColor
+ * @attr ref R.styleable#MentionsEditText_mentionTextBackgroundColor
+ * @attr ref R.styleable#MentionsEditText_selectedMentionTextColor
+ * @attr ref R.styleable#MentionsEditText_selectedMentionTextBackgroundColor
  */
 public class MentionsEditText extends EditText implements TokenSource {
 
@@ -68,25 +81,31 @@ public class MentionsEditText extends EditText implements TokenSource {
     private boolean mAvoidPrefixOnTap = false;
     private String mAvoidedPrefix;
 
-    public MentionsEditText(Context context) {
+    private MentionSpanFactory mentionSpanFactory;
+    private MentionSpanConfig mentionSpanConfig;
+
+    public MentionsEditText(@NonNull Context context) {
         super(context);
-        init();
+        init(null, 0);
     }
 
-    public MentionsEditText(Context context, AttributeSet attrs) {
+    public MentionsEditText(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
-        init();
+        init(attrs, 0);
     }
 
-    public MentionsEditText(Context context, AttributeSet attrs, int defStyle) {
+    public MentionsEditText(@NonNull Context context, @Nullable AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        init();
+        init(attrs, defStyle);
     }
 
     /**
      * Initialization method called by all constructors.
      */
-    private void init() {
+    private void init(@Nullable AttributeSet attrs, int defStyleAttr) {
+        // Get the mention span config from custom attributes
+        mentionSpanConfig = parseMentionSpanConfigFromAttributes(attrs, defStyleAttr);
+
         // Must set movement method in order for MentionSpans to be clickable
         setMovementMethod(MentionsMovementMethod.getInstance());
 
@@ -95,6 +114,31 @@ public class MentionsEditText extends EditText implements TokenSource {
 
         // Start watching itself for text changes
         addTextChangedListener(mInternalTextWatcher);
+
+        // Use default MentionSpanFactory initially
+        mentionSpanFactory = new MentionSpanFactory();
+    }
+
+    private MentionSpanConfig parseMentionSpanConfigFromAttributes(@Nullable AttributeSet attrs, int defStyleAttr) {
+        final Context context = getContext();
+        MentionSpanConfig.Builder builder = new MentionSpanConfig.Builder();
+        if (attrs == null) {
+            return builder.build();
+        }
+
+        TypedArray attributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.MentionsEditText, defStyleAttr, 0);
+        @ColorInt int normalTextColor = attributes.getColor(R.styleable.MentionsEditText_mentionTextColor, -1);
+        builder.setMentionTextColor(normalTextColor);
+        @ColorInt int normalBgColor = attributes.getColor(R.styleable.MentionsEditText_mentionTextBackgroundColor, -1);
+        builder.setMentionTextBackgroundColor(normalBgColor);
+        @ColorInt int selectedTextColor = attributes.getColor(R.styleable.MentionsEditText_selectedMentionTextColor, -1);
+        builder.setSelectedMentionTextColor(selectedTextColor);
+        @ColorInt int selectedBgColor = attributes.getColor(R.styleable.MentionsEditText_selectedMentionTextBackgroundColor, -1);
+        builder.setSelectedMentionTextBackgroundColor(selectedBgColor);
+
+        attributes.recycle();
+
+        return builder.build();
     }
 
     // --------------------------------------------------
@@ -745,7 +789,7 @@ public class MentionsEditText extends EditText implements TokenSource {
 
     private void insertMentionInternal(@NonNull Mentionable mention, @NonNull Editable text, int start, int end) {
         // Insert the span into the editor
-        MentionSpan mentionSpan = new MentionSpan(getContext(), mention);
+        MentionSpan mentionSpan = mentionSpanFactory.createMentionSpan(mention, mentionSpanConfig);
         String name = mention.getSuggestiblePrimaryText();
 
         mBlockCompletion = true;
@@ -996,6 +1040,22 @@ public class MentionsEditText extends EditText implements TokenSource {
     }
 
     // --------------------------------------------------
+    // MentionSpan Factory
+    // --------------------------------------------------
+
+    /**
+     * Custom factory used when creating a {@link MentionSpan}.
+     */
+    public static class MentionSpanFactory {
+
+        @NonNull
+        public MentionSpan createMentionSpan(@NonNull Mentionable mention,
+                                             @Nullable MentionSpanConfig config) {
+            return (config != null) ? new MentionSpan(mention, config) : new MentionSpan(mention);
+        }
+    }
+
+    // --------------------------------------------------
     // MentionsMovementMethod Class
     // --------------------------------------------------
 
@@ -1050,7 +1110,7 @@ public class MentionsEditText extends EditText implements TokenSource {
      *
      * @param tokenizer the {@link Tokenizer} to use
      */
-    public void setTokenizer(final @Nullable Tokenizer tokenizer) {
+    public void setTokenizer(@Nullable final Tokenizer tokenizer) {
         mTokenizer = tokenizer;
     }
 
@@ -1060,7 +1120,7 @@ public class MentionsEditText extends EditText implements TokenSource {
      *
      * @param queryTokenReceiver the {@link QueryTokenReceiver} to use
      */
-    public void setQueryTokenReceiver(final @Nullable QueryTokenReceiver queryTokenReceiver) {
+    public void setQueryTokenReceiver(@Nullable final QueryTokenReceiver queryTokenReceiver) {
         mQueryTokenReceiver = queryTokenReceiver;
     }
 
@@ -1069,8 +1129,26 @@ public class MentionsEditText extends EditText implements TokenSource {
      *
      * @param suggestionsVisibilityManager the {@link SuggestionsVisibilityManager} to use
      */
-    public void setSuggestionsVisibilityManager(final @Nullable SuggestionsVisibilityManager suggestionsVisibilityManager) {
+    public void setSuggestionsVisibilityManager(@Nullable final SuggestionsVisibilityManager suggestionsVisibilityManager) {
         mSuggestionsVisibilityManager = suggestionsVisibilityManager;
+    }
+
+    /**
+     * Sets the factory used to create MentionSpans within this class.
+     *
+     * @param factory the {@link MentionSpanFactory} to use
+     */
+    public void setMentionSpanFactory(@NonNull final MentionSpanFactory factory) {
+        mentionSpanFactory = factory;
+    }
+
+    /**
+     * Sets the configuration options used when creating MentionSpans.
+     *
+     * @param config the {@link MentionSpanConfig} to use
+     */
+    public void setMentionSpanConfig(@NonNull final MentionSpanConfig config) {
+        mentionSpanConfig = config;
     }
 
     /**

--- a/spyglass/src/main/res/layout/editor_fragment.xml
+++ b/spyglass/src/main/res/layout/editor_fragment.xml
@@ -1,12 +1,11 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.linkedin.android.richeditor.v2.RichEditorFragment">
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context="com.linkedin.android.richeditor.v2.RichEditorFragment">
 
     <com.linkedin.android.spyglass.ui.RichEditorView
         android:id="@+id/rich_editor"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
+        android:layout_height="match_parent"/>
 </FrameLayout>

--- a/spyglass/src/main/res/layout/editor_view.xml
+++ b/spyglass/src/main/res/layout/editor_view.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:padding="0dp">
@@ -19,11 +18,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignBottom="@+id/text_editor"
-        android:layout_alignRight="@+id/text_editor"
         android:layout_alignEnd="@+id/text_editor"
+        android:layout_alignRight="@+id/text_editor"
         android:layout_marginBottom="12dp"
-        android:layout_marginRight="12dp"
         android:layout_marginEnd="12dp"
+        android:layout_marginRight="12dp"
         android:textSize="15sp"
         android:textStyle="bold"/>
 
@@ -33,5 +32,4 @@
         android:layout_height="match_parent"
         android:layout_below="@+id/text_editor"
         android:visibility="gone"/>
-
 </merge>

--- a/spyglass/src/main/res/values/attrs.xml
+++ b/spyglass/src/main/res/values/attrs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="mentionTextColor" format="color"/>
+    <attr name="mentionTextBackgroundColor" format="color"/>
+    <attr name="selectedMentionTextColor" format="color"/>
+    <attr name="selectedMentionTextBackgroundColor" format="color"/>
+
+    <declare-styleable name="MentionsEditText">
+        <attr name="mentionTextColor"/>
+        <attr name="mentionTextBackgroundColor"/>
+        <attr name="selectedMentionTextColor"/>
+        <attr name="selectedMentionTextBackgroundColor"/>
+    </declare-styleable>
+
+    <declare-styleable name="RichEditorView">
+        <attr name="mentionTextColor"/>
+        <attr name="mentionTextBackgroundColor"/>
+        <attr name="selectedMentionTextColor"/>
+        <attr name="selectedMentionTextBackgroundColor"/>
+    </declare-styleable>
+</resources>

--- a/spyglass/src/main/res/values/colors.xml
+++ b/spyglass/src/main/res/values/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="mention_selected">#0077b5</color>
-    <color name="mention_unselected">#00a0dc</color>
-</resources>

--- a/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
@@ -39,7 +39,7 @@ public class MentionsEditableTest {
     public void setUp() {
         mEditable = new MentionsEditable("Hi @" + NAME + " bye");
         TestMention tm = new TestMention(NAME);
-        mMentionSpan = new MentionSpan(Robolectric.application, tm);
+        mMentionSpan = new MentionSpan(tm);
     }
 
     @Test

--- a/spyglass/src/test/java/com/linkedin/android/spyglass/tokenization/impl/WordTokenizerTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/tokenization/impl/WordTokenizerTest.java
@@ -350,7 +350,7 @@ public class WordTokenizerTest {
     private void setTestSpan(String name, int start) throws Exception {
         // Set a test span in the editor around a person's name
         TestMention mention = new TestMention(name);
-        MentionSpan span = new MentionSpan(Robolectric.application, mention);
+        MentionSpan span = new MentionSpan(mention);
         mRichEditor.getText().setSpan(span, start, start + mention.getSuggestiblePrimaryText().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 

--- a/spyglass/src/test/java/com/linkedin/android/spyglass/ui/RichEditorViewTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/ui/RichEditorViewTest.java
@@ -83,9 +83,9 @@ public class RichEditorViewTest {
         assertEquals(0, mRichEditor.getMentionSpans().size());
 
         Mentionable mention1 = new TestMention("Shoulong Li");
-        MentionSpan span1 = new MentionSpan(Robolectric.application, mention1);
+        MentionSpan span1 = new MentionSpan(mention1);
         Mentionable mention2 = new TestMention("Deepank Gupta");
-        MentionSpan span2 = new MentionSpan(Robolectric.application, mention2);
+        MentionSpan span2 = new MentionSpan(mention2);
 
         mRichEditor.getText().setSpan(span1, 14, 14 + mention1.getSuggestiblePrimaryText().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         mRichEditor.getText().setSpan(span2, 30, 30 + mention2.getSuggestiblePrimaryText().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);


### PR DESCRIPTION
1. Adds a MentionSpanFactory that allows devs to provide their own implementation of MentionSpan when inserting a new mention.
2. Adds custom color XML attributes to the MentionsEditText and RichEditorView to adjust mention colors easily.

This commit resolves #18.