### PR TITLE
Fix bug: Having emoticon characters in the mention causes problem to delete.

### DIFF
--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -636,8 +636,8 @@ public class MentionsEditText extends EditText implements TokenSource {
         int cursor = getSelectionStart();
         MentionsEditable text = getMentionsText();
         MentionSpan prevSpan = text.getMentionSpanEndingAt(cursor);
-
-        if (count == (after + 1) && prevSpan != null) {
+        boolean isNeedToMarkSpan = (count == (after + 1) || after == 0) && prevSpan != null;
+        if (isNeedToMarkSpan) {
 
             // Cursor was directly behind a span and was moved back one, so delete it if selected,
             // or select it if not already selected


### PR DESCRIPTION
(1)Before someone fix bug, "Cut/Copy text is not working on the mention in the message",  the condition, "after == 0 && prevSpan != null", is enough to markSpans.
(2)Now, if user delete a normal text or the mention end with emoji, the variable "after" will equal to 0. But if user delete a normal mention, the variable "count" will equal to the length of user's last  name and the variable "after" will equal to length-1.
Note: I only used MentionEditText in my project.