### PR TITLE
Fixed a bug which the RichEditorView text counter shows up after showing the suggest…

### DIFF
--- a/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/SimpleMentions.java
+++ b/spyglass-sample/src/main/java/com/linkedin/android/spyglass/sample/samples/SimpleMentions.java
@@ -42,6 +42,7 @@ public class SimpleMentions extends AppCompatActivity implements QueryTokenRecei
         super.onCreate(savedInstanceState);
         setContentView(R.layout.simple_mentions);
         editor = findViewById(R.id.editor);
+        editor.displayTextCounter(false);
         editor.setQueryTokenReceiver(this);
         editor.setHint(getResources().getString(R.string.type_city));
         cities = new City.CityLoader(getResources());

--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/RichEditorView.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/RichEditorView.java
@@ -93,6 +93,7 @@ public class RichEditorView extends RelativeLayout implements TextWatcher, Query
     private int mBeyondCountLimitTextColor = Color.RED;
 
     private boolean mWaitingForFirstResult = false;
+    private boolean mDisplayTextCount = true;
 
     // --------------------------------------------------
     // Constructors & Initialization
@@ -254,6 +255,7 @@ public class RichEditorView extends RelativeLayout implements TextWatcher, Query
      * @param display true to display the text counter view
      */
     public void displayTextCounter(boolean display) {
+        mDisplayTextCount = display;
         if (display) {
             mTextCounterView.setVisibility(TextView.VISIBLE);
         } else {
@@ -374,7 +376,7 @@ public class RichEditorView extends RelativeLayout implements TextWatcher, Query
             }
         } else {
             disableSpellingSuggestions(false);
-            mTextCounterView.setVisibility(View.VISIBLE);
+            mTextCounterView.setVisibility(mDisplayTextCount ? View.VISIBLE : View.GONE);
             mSuggestionsList.setVisibility(View.GONE);
             mMentionsEditText.setPadding(mMentionsEditText.getPaddingLeft(), mMentionsEditText.getPaddingTop(), mMentionsEditText.getPaddingRight(), mPrevEditTextBottomPadding);
             if (mPrevEditTextParams == null) {


### PR DESCRIPTION
Hello,

This fix is to solve the issue https://github.com/linkedin/Spyglass/issues/81.
It always displays the counter even when it should not by calling the displaySuggestions(boolean).