### PR TITLE
Fix issue with text insertion on some keyboards

### DIFF
--- a/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
+++ b/spyglass/src/test/java/com/linkedin/android/spyglass/mentions/MentionsEditableTest.java
@@ -87,8 +87,16 @@ public class MentionsEditableTest {
     }
 
     @Test
-    public void testMapToDeleteCharacterInsteadOfAppend() {
+    public void testMapToDeleteCharacterInsteadOfAppendWithoutMentionSpan() {
         mEditable = new MentionsEditable("Hello World");
+        mEditable.replace(11, 11, "Worl");
+        assertEquals("Hello WorldWorl", mEditable.toString());
+    }
+
+    @Test
+    public void testMapToDeleteCharacterInsteadOfAppendWithMentionSpan() {
+        mEditable = new MentionsEditable("Hello World");
+        mEditable.setSpan(mMentionSpan, 6, 11, Spanned.SPAN_EXCLUSIVE_INCLUSIVE);
         mEditable.replace(11, 11, "Worl");
         assertEquals("Hello Worl", mEditable.toString());
     }


### PR DESCRIPTION
Certain keyboards treat deleting the last character in a mention (first
if the cursor is moving right-to-left) as appending the previous word
minus the last character. We are not sure why this behavior differs
between keyboards, but we added some code to negate this behavior many
years ago.

However, the code that negated this behavior had an unwanted side
effect in that it also could impact text typed normally (without any
mention spans).

To offer a better experience, this commit adds a check to ensure that
the previous string actually contains a mention. If it contains a
mention, we will maintain the previous custom behavior to address the
issue. However, if there is no mention, we will not intercept the
behavior. While this is not a fix for the underlying issue, it should
improve the user experience for most cases where users were seeing this
issue.

More details: https://github.com/linkedin/Spyglass/issues/105