### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ LIBRARY_GIT_CONNECTION=git@github.com:linkedin/Spyglass.git
 
 # Gradle settings
 org.gradle.daemon=true
-org.gradle.configureondemand=false
+org.gradle.configureondemand=true
 org.gradle.parallel=true
 
 #For AndroidX migration


### PR DESCRIPTION

[Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand). Configuration on demand tells Gradle to configure modules that only are relevant to the requested tasks instead of configuring all of them. We can enable this feature by setting `org.gradle.configureondemand=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
