### PR TITLE
Fix memory leak when saving MentionsEditText state

### DIFF
--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -1379,7 +1379,9 @@ public class MentionsEditText extends EditText implements TokenSource {
     @Override
     public Parcelable onSaveInstanceState() {
         Parcelable parcelable = super.onSaveInstanceState();
-        return new SavedState(parcelable, getMentionsText());
+        // Save a copy of MentionsEditable to avoid leaking memory from persisted watchers,
+        // as is done in TextView.onSaveInstanceState().
+        return new SavedState(parcelable, new MentionsEditable(getMentionsText()));
     }
 
     @Override


### PR DESCRIPTION
`MentionsEditable` is a `SpannableStringBuilder`, which may contain `Span`s such as `TextWatcher` which may contain references to `View`s. To avoid leaking the view tree, we should copy the `MentionsEditable` before saving it - this will not copy the `TextWatcher`s to the new instance since they are `NoCopySpan`s.

This copying is also performed in the base `TextView`: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/widget/TextView.java;l=6215?q=TextView.java