### PR TITLE
bugfix(edit-text): Ensure that the Samsung keyboard cannot remove mentions with it's grammatical corrections

### DIFF
--- a/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
+++ b/spyglass/src/main/java/com/linkedin/android/spyglass/ui/MentionsEditText.java
@@ -782,7 +782,7 @@ public class MentionsEditText extends EditText implements TokenSource {
     }
 
     /**
-     * Removes any {@link DeleteSpan}s and the text within them from
+     * Removes any {@link com.linkedin.android.spyglass.ui.MentionsEditText.DeleteSpan}s and the text within them from
      * the given text.
      *
      * @param text the editable containing DeleteSpans to remove


### PR DESCRIPTION
I have been experiencing issues related to persisting mentions when the user is running a recent Samsung device. It looks to me like this issue had been attempted to be fixed with the use of the `PlaceholderSpan`, however in my case I'm seeing that even these are removed from the text. 

My fix involves persisting the placeholder in the `MentionsEditText` class, rather than holding onto them as part of the spannable string. This seems to have fixed the issue for now.

I'm not sure that this project is actively maintained, but would be grateful if anyone can offer advice on this and whether or not my approach is appropriate.